### PR TITLE
Disable compression on POST responses

### DIFF
--- a/NextPvr/LiveTvService.cs
+++ b/NextPvr/LiveTvService.cs
@@ -193,7 +193,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ManageService/Get/SortedFilteredList?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ManageService/Get/SortedFilteredList?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var filterOptions = new
@@ -371,7 +372,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ManageService/Get/SortedFilteredList?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ManageService/Get/SortedFilteredList?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var filterOptions = new
@@ -424,7 +426,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ManageService/Get/SortedFilteredList?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ManageService/Get/SortedFilteredList?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var filterOptions = new

--- a/NextPvr/LiveTvService.cs
+++ b/NextPvr/LiveTvService.cs
@@ -38,7 +38,6 @@ namespace NextPvr
 
         private string Sid { get; set; }
         private DateTimeOffset LastUpdatedSidDateTime { get; set; }
-        private ICryptoProvider _cryptoProvider;
         private IFileSystem _fileSystem;
 
         public DateTimeOffset LastRecordingChange = DateTimeOffset.MinValue;
@@ -49,7 +48,6 @@ namespace NextPvr
             _jsonSerializer = jsonSerializer;
             _logger = logger;
             LastUpdatedSidDateTime = DateTime.UtcNow;
-            _cryptoProvider = cryptoProvider;
             _fileSystem = fileSystem;
         }
 
@@ -144,9 +142,7 @@ namespace NextPvr
 
         public string GetMd5Hash(string value)
         {
-            var hashValue = _cryptoProvider.ComputeMD5(new UTF8Encoding().GetBytes(value));
-            //Bit convertor return the byte to string as all caps hex values seperated by "-"
-            return BitConverter.ToString(hashValue).Replace("-", "").ToLowerInvariant();
+            return value.GetMD5().ToString();
         }
 
         /// <summary>

--- a/NextPvr/LiveTvService.cs
+++ b/NextPvr/LiveTvService.cs
@@ -325,7 +325,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ScheduleService/Record?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ScheduleService/Record?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var timerSettings = await GetDefaultScheduleSettings(cancellationToken).ConfigureAwait(false);
@@ -470,7 +471,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ScheduleService/Record?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ScheduleService/Record?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var timerSettings = await GetDefaultScheduleSettings(cancellationToken).ConfigureAwait(false);
@@ -551,7 +553,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ScheduleService/UpdateRecurr?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ScheduleService/UpdateRecurr?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var timerSettings = await GetDefaultScheduleSettings(cancellationToken).ConfigureAwait(false);
@@ -600,7 +603,8 @@ namespace NextPvr
             var options = new HttpRequestOptions
             {
                 CancellationToken = cancellationToken,
-                Url = string.Format("{0}/public/ScheduleService/UpdateRec?sid={1}", baseUrl, Sid)
+                Url = string.Format("{0}/public/ScheduleService/UpdateRec?sid={1}", baseUrl, Sid),
+                DecompressionMethod = CompressionMethod.None
             };
 
             var timerSettings = await GetDefaultScheduleSettings(cancellationToken).ConfigureAwait(false);

--- a/NextPvr/NextPvr.csproj
+++ b/NextPvr/NextPvr.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
-    <FileVersion>1.1.0</FileVersion>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <FileVersion>2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NextPvr/NextPvr.csproj
+++ b/NextPvr/NextPvr.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <FileVersion>1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.4-*" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-nextpvr"
 guid: "9574ac10-bf23-49bc-949f-924f23cfa48f"
-version: "1" # Please increment with each pull request
-jellyfin_version: "10.3.0" # The earliest binary-compatible version
+version: "1.1.0" # Please increment with each pull request
+jellyfin_version: "10.3.7" # The earliest binary-compatible version
 nicename: "NextPVR"
 description: "Jellyfin LiveTV plugin for NextPVR"
 overview: >

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "jellyfin-plugin-nextpvr"
 guid: "9574ac10-bf23-49bc-949f-924f23cfa48f"
 version: "1.1.0" # Please increment with each pull request
-jellyfin_version: "10.3.7" # The earliest binary-compatible version
+jellyfin_version: "10.4-*" # The earliest binary-compatible version
 nicename: "NextPVR"
 description: "Jellyfin LiveTV plugin for NextPVR"
 overview: >

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-nextpvr"
 guid: "9574ac10-bf23-49bc-949f-924f23cfa48f"
-version: "1.1.0" # Please increment with each pull request
+version: "2" # Please increment with each pull request
 jellyfin_version: "10.4-*" # The earliest binary-compatible version
 nicename: "NextPVR"
 description: "Jellyfin LiveTV plugin for NextPVR"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "jellyfin-plugin-nextpvr"
 guid: "9574ac10-bf23-49bc-949f-924f23cfa48f"
 version: "2" # Please increment with each pull request
-jellyfin_version: "10.4-*" # The earliest binary-compatible version
+jellyfin_version: "10.4.0" # The earliest binary-compatible version
 nicename: "NextPVR"
 description: "Jellyfin LiveTV plugin for NextPVR"
 overview: >


### PR DESCRIPTION
## Summary
Recent changes to `HttpClientManager.SendAsyncInternal(HttpRequestOptions options, HttpMethod httpMethod)` appears to have caused problems with the decompression of `POST` responses because the default compression method is `Deflate`, but the `response.Content` is not decompressed. 

This works around that by simply disabling compression on those requests, which generally improves performance since the NPVR server is usually `localhost` anyway.