### PR TITLE
Changes for 10.8 alpha2

### DIFF
--- a/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
+++ b/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <FileVersion>5.0.0.0</FileVersion>
   </PropertyGroup>
@@ -14,9 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.8.0-alpha2" />
+    <PackageReference Include="Jellyfin.Extensions" Version="10.8.0-alpha2" />
     <PackageReference Include="System.Memory" Version="4.5.*" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.NextPVR/RecordingsChannel.cs
+++ b/Jellyfin.Plugin.NextPVR/RecordingsChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -261,13 +261,12 @@ namespace Jellyfin.Plugin.NextPVR
 
                 useCachedRecordings = true;
             }
-
+            List<ChannelItemInfo> pluginItems = new List<ChannelItemInfo>();
+            pluginItems.AddRange(allRecordings.Where(filter).Select(ConvertToChannelItem));
             var result = new ChannelItemResult()
             {
-                Items = new List<ChannelItemInfo>()
+                Items = pluginItems
             };
-
-            result.Items.AddRange(allRecordings.Where(filter).Select(ConvertToChannelItem));
 
             return result;
         }
@@ -319,6 +318,7 @@ namespace Jellyfin.Plugin.NextPVR
 
         private async Task<ChannelItemResult> GetRecordingGroups(InternalChannelItemQuery query, CancellationToken cancellationToken)
         {
+            List<ChannelItemInfo> pluginItems = new List<ChannelItemInfo>();
             var service = GetService();
             if (useCachedRecordings == false)
             {
@@ -326,17 +326,11 @@ namespace Jellyfin.Plugin.NextPVR
                 var channels = await service.GetChannelsAsync(cancellationToken).ConfigureAwait(false);
                 useCachedRecordings = true;
             }
-
-            var result = new ChannelItemResult()
-            {
-                Items = new List<ChannelItemInfo>()
-            };
-
             var series = allRecordings
                 .Where(i => i.IsSeries)
                 .ToLookup(i => i.Name, StringComparer.OrdinalIgnoreCase);
 
-            result.Items.AddRange(series.OrderBy(i => i.Key).Select(i => new ChannelItemInfo
+            pluginItems.AddRange(series.OrderBy(i => i.Key).Select(i => new ChannelItemInfo
             {
                 Name = i.Key,
                 FolderType = ChannelFolderType.Container,
@@ -350,7 +344,7 @@ namespace Jellyfin.Plugin.NextPVR
 
             if (kids != null)
             {
-                result.Items.Add(new ChannelItemInfo
+                pluginItems.Add(new ChannelItemInfo
                 {
                     Name = "Kids",
                     FolderType = ChannelFolderType.Container,
@@ -363,7 +357,7 @@ namespace Jellyfin.Plugin.NextPVR
             var movies = allRecordings.FirstOrDefault(i => i.IsMovie);
             if (movies != null)
             {
-                result.Items.Add(new ChannelItemInfo
+                pluginItems.Add(new ChannelItemInfo
                 {
                     Name = "Movies",
                     FolderType = ChannelFolderType.Container,
@@ -376,7 +370,7 @@ namespace Jellyfin.Plugin.NextPVR
             var news = allRecordings.FirstOrDefault(i => i.IsNews);
             if (news != null)
             {
-                result.Items.Add(new ChannelItemInfo
+                pluginItems.Add(new ChannelItemInfo
                 {
                     Name = "News",
                     FolderType = ChannelFolderType.Container,
@@ -389,7 +383,7 @@ namespace Jellyfin.Plugin.NextPVR
             var sports = allRecordings.FirstOrDefault(i => i.IsSports);
             if (sports != null)
             {
-                result.Items.Add(new ChannelItemInfo
+                pluginItems.Add(new ChannelItemInfo
                 {
                     Name = "Sports",
                     FolderType = ChannelFolderType.Container,
@@ -402,7 +396,7 @@ namespace Jellyfin.Plugin.NextPVR
             var other = allRecordings.FirstOrDefault(i => !i.IsSports && !i.IsNews && !i.IsMovie && !i.IsKids && !i.IsSeries);
             if (other != null)
             {
-                result.Items.Add(new ChannelItemInfo
+                pluginItems.Add(new ChannelItemInfo
                 {
                     Name = "Others",
                     FolderType = ChannelFolderType.Container,
@@ -411,7 +405,10 @@ namespace Jellyfin.Plugin.NextPVR
                     ImageUrl = other.ImageUrl
                 });
             }
-
+            var result = new ChannelItemResult()
+            {
+                Items = pluginItems
+            };
             return result;
         }
     }

--- a/Jellyfin.Plugin.NextPVR/Responses/CancelRecordingResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/CancelRecordingResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,13 +7,13 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class CancelDeleteRecordingResponse
     {
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public async Task<bool?> RecordingError(Stream stream, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/ChannelResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/ChannelResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
@@ -16,8 +16,7 @@ namespace Jellyfin.Plugin.NextPVR.Responses
     {
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         private readonly string _baseUrl;
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
-
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
         public ChannelResponse(string baseUrl)
         {
             _baseUrl = baseUrl;

--- a/Jellyfin.Plugin.NextPVR/Responses/InitializeResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/InitializeResponse.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -10,7 +10,7 @@ namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class InitializeResponse
     {
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
         
         public async Task<bool> LoggedIn(Stream stream, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/InstantiateResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/InstantiateResponse.cs
@@ -4,13 +4,13 @@ using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class InstantiateResponse
     {
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public async Task<ClientKeys> GetClientKeys(Stream stream, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/LastUpdateResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/LastUpdateResponse.cs
@@ -5,14 +5,14 @@ using MediaBrowser.Controller.LiveTv;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 using System.Text.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class LastUpdateResponse
     {
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
         public async Task<DateTimeOffset> GetUpdateTime(Stream stream, ILogger<LiveTvService> logger)
         {
             var root = await JsonSerializer.DeserializeAsync<RootObject>(stream, _jsonOptions).ConfigureAwait(false);

--- a/Jellyfin.Plugin.NextPVR/Responses/ListingsResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/ListingsResponse.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
@@ -18,7 +18,7 @@ namespace Jellyfin.Plugin.NextPVR.Responses
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         private readonly string _baseUrl;
         private string _channelId;
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public ListingsResponse(string baseUrl)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/RecordingResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/RecordingResponse.cs
@@ -9,7 +9,7 @@ using MediaBrowser.Model.LiveTv;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 using System.Text.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
@@ -20,7 +20,7 @@ namespace Jellyfin.Plugin.NextPVR.Responses
         private readonly string _baseUrl;
         private IFileSystem _fileSystem;
         private readonly ILogger<LiveTvService> _logger;
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public RecordingResponse(string baseUrl, IFileSystem fileSystem, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/RecurringResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/RecurringResponse.cs
@@ -9,7 +9,7 @@ using MediaBrowser.Model.LiveTv;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 using System.Threading.Tasks;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
@@ -20,7 +20,7 @@ namespace Jellyfin.Plugin.NextPVR.Responses
         private readonly string _baseUrl;
         private IFileSystem _fileSystem;
         private readonly ILogger<LiveTvService> _logger;
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public RecurringResponse(string baseUrl, IFileSystem fileSystem, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/SettingResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/SettingResponse.cs
@@ -5,14 +5,14 @@ using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class SettingResponse
     {
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public async Task<bool> GetDefaultSettings(Stream stream, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/TimerDefaultsResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/TimerDefaultsResponse.cs
@@ -5,14 +5,14 @@ using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.NextPVR.Helpers;
 using System.Threading.Tasks;
 using System.Text.Json;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class TimerDefaultsResponse
     {
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public async Task<SeriesTimerInfo> GetDefaultTimerInfo(Stream stream, ILogger<LiveTvService> logger)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/TunerResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/TunerResponse.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.LiveTv;
 
@@ -11,7 +11,7 @@ namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class TunerResponse
     {
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public async Task<List<LiveTvTunerInfo>> LiveTvTunerInfos(Stream stream)
         {

--- a/Jellyfin.Plugin.NextPVR/Responses/VersionCheckResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/VersionCheckResponse.cs
@@ -2,13 +2,13 @@
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Json;
+using Jellyfin.Extensions.Json;
 
 namespace Jellyfin.Plugin.NextPVR.Responses
 {
     public class VersionCheckResponse
     {
-        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.GetOptions();
+        private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
 
         public async Task<bool> UpdateAvailable(Stream stream)
         {

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,9 @@
 name: "NextPVR"
 guid: "9574ac10-bf23-49bc-949f-924f23cfa48f"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-nextpvr.png"
-version: "6"
-targetAbi: "10.7.0.0"
-framework: "net5.0"
+version: "7"
+targetAbi: "10.8.0.0"
+framework: "net6.0"
 overview: "Live TV plugin for NextPVR"
 description: >
   Provides access to live TV, program guide, and recordings from NextPVR.


### PR DESCRIPTION
Move to .net 6.  Use 10.8 alpha2 APIs.  

Needs to be modified for 10.8 release controllers