### PR TITLE
Allow dynamic recording URLs

### DIFF
--- a/Jellyfin.Plugin.NextPVR/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.NextPVR/Configuration/PluginConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using Jellyfin.Plugin.NextPVR.Entities;
 
 using MediaBrowser.Model.Plugins;
@@ -54,6 +55,10 @@ public class PluginConfiguration : BasePluginConfiguration
     public int PrePaddingSeconds { get; set; }
 
     public int PostPaddingSeconds { get; set; }
+
+    public string StoredSid { get; set; }
+
+    public DateTime SidModified { get; set; }
 
     /// <summary>
     /// Gets or sets the genre mappings, to map localised NextPVR genres, to Jellyfin categories.

--- a/Jellyfin.Plugin.NextPVR/Helpers/ChannelHelper.cs
+++ b/Jellyfin.Plugin.NextPVR/Helpers/ChannelHelper.cs
@@ -1,6 +1,7 @@
-﻿using MediaBrowser.Model.LiveTv;
+using MediaBrowser.Model.LiveTv;
 
 namespace Jellyfin.Plugin.NextPVR.Helpers;
+
 public static class ChannelHelper
 {
     public static ChannelType GetChannelType(int channelType)

--- a/Jellyfin.Plugin.NextPVR/Helpers/UtilsHelper.cs
+++ b/Jellyfin.Plugin.NextPVR/Helpers/UtilsHelper.cs
@@ -2,6 +2,7 @@ using MediaBrowser.Model.LiveTv;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.NextPVR.Helpers;
+
 public static class UtilsHelper
 {
     public static void DebugInformation(ILogger<LiveTvService> logger, string message)

--- a/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
+++ b/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Memory" Version="4.5.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.NextPVR/RecordingsChannel.cs
+++ b/Jellyfin.Plugin.NextPVR/RecordingsChannel.cs
@@ -235,7 +235,7 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
             PremiereDate = item.OriginalAirDate,
             ProductionYear = item.ProductionYear,
             Type = ChannelItemType.Media,
-            DateModified = item.DateLastUpdated,
+            DateModified = LiveTvService.Instance.DateRecordingModified,
             Overview = item.Overview,
             IsLiveStream = item.Status == RecordingStatus.InProgress,
             Etag = item.Status.ToString()

--- a/Jellyfin.Plugin.NextPVR/Responses/RecordingResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/RecordingResponse.cs
@@ -98,7 +98,7 @@ public class RecordingResponse
             }
             else
             {
-                info.Url = $"{_baseUrl}/live?recording={i.Id}&sid=jellyfin";
+                info.Url = $"{_baseUrl}/live?recording={i.Id}&sid={LiveTvService.Instance.Sid}";
             }
         }
 


### PR DESCRIPTION
On creation ensure all recordings have a valid security ID token (sid).   On a new connection attempt to re-authenticate the sid  keeping saved URLs  valid.   There are cached json file for the recordings so if there is a failure recordings may not play until the 3hr cache timeout is met.  The change of a failure is low typically only after a server IP change,  a long pause in connections, or a database rebuild  Unfortunately scanning tasks do not remove the cached files.

The modification date of the recording is the date of a sid change and it is also persisted so recordings are not rescanned each load.
