### PR TITLE
Recording enhancements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>9.0.0.0</Version>
-        <AssemblyVersion>9.0.0.0</AssemblyVersion>
-        <FileVersion>9.0.0.0</FileVersion>
+        <Version>10.0.0.0</Version>
+        <AssemblyVersion>10.0.0.0</AssemblyVersion>
+        <FileVersion>10.0.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.NextPVR/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.NextPVR/Configuration/PluginConfiguration.cs
@@ -19,6 +19,9 @@ public class PluginConfiguration : BasePluginConfiguration
         NewEpisodes = false;
         RecordingDefault = "2";
         RecordingTransport = 1;
+        EnableInProgress = false;
+        PollInterval = 20;
+        BackendVersion = 0;
         // Initialise this
         GenreMappings = new SerializableDictionary<string, List<string>>();
         GenreMappings["GENRESPORT"] = new List<string>()
@@ -38,9 +41,19 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string WebServiceUrl { get; set; }
 
+    public string CurrentWebServiceURL { get; set; }
+
+    public int BackendVersion { get; set; }
+
     public string Pin { get; set; }
 
+    public string StoredSid { get; set; }
+
     public bool EnableDebugLogging { get; set; }
+
+    public bool EnableInProgress { get; set; }
+
+    public int PollInterval { get; set; }
 
     public bool NewEpisodes { get; set; }
 
@@ -56,9 +69,7 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public int PostPaddingSeconds { get; set; }
 
-    public string StoredSid { get; set; }
-
-    public DateTime SidModified { get; set; }
+    public DateTime RecordingModificationTime { get; set; }
 
     /// <summary>
     /// Gets or sets the genre mappings, to map localised NextPVR genres, to Jellyfin categories.

--- a/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
+++ b/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
     <NoWarn>CA2227;CA1002;CA2007;CS1591</NoWarn>
+    <Version>10.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
+++ b/Jellyfin.Plugin.NextPVR/Jellyfin.Plugin.NextPVR.csproj
@@ -7,7 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
     <NoWarn>CA2227;CA1002;CA2007;CS1591</NoWarn>
-    <Version>10.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.NextPVR/RecordingsChannel.cs
+++ b/Jellyfin.Plugin.NextPVR/RecordingsChannel.cs
@@ -1,39 +1,55 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Extensions;
 using Jellyfin.Plugin.NextPVR.Entities;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Channels;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.LiveTv;
 using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.NextPVR;
 
-public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISupportsLatestMedia, ISupportsMediaProbe, IHasFolderAttributes, IDisposable
+public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISupportsLatestMedia, ISupportsMediaProbe, IHasFolderAttributes, IDisposable, IHasItemChangeMonitor
 {
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<RecordingsChannel> _logger;
     private readonly CancellationTokenSource _cancellationToken;
+    private readonly string _recordingCacheDirectory;
+    private static SemaphoreSlim _semaphore;
+
     private Timer _updateTimer;
     private DateTimeOffset _lastUpdate = DateTimeOffset.FromUnixTimeSeconds(0);
 
     private IEnumerable<MyRecordingInfo> _allRecordings;
-    private bool _useCachedRecordings;
+    private bool _useCachedRecordings = false;
+    private DateTime _cachedRecordingModificationTime;
+    private string _cachekeyBase;
+    private int _pollInterval = -1;
 
-    public RecordingsChannel()
+    public RecordingsChannel(IApplicationPaths applicationPaths, ILibraryManager libraryManager, IFileSystem fileSystem, ILogger<RecordingsChannel> logger)
     {
-        var interval = TimeSpan.FromSeconds(20);
-        _updateTimer = new Timer(OnUpdateTimerCallbackAsync, null, interval, interval);
-        if (_updateTimer != null)
-        {
-            _cancellationToken = new CancellationTokenSource();
-        }
+        _fileSystem = fileSystem;
+        _logger = logger;
+        string channelId = libraryManager.GetNewItemId($"Channel {Name}", typeof(Channel)).ToString("N", CultureInfo.InvariantCulture);
+        string version = BaseExtensions.GetMD5($"{DataVersion}2").ToString("N", CultureInfo.InvariantCulture);
+        _recordingCacheDirectory = Path.Join(applicationPaths.CachePath, "channels", channelId, version);
+        CleanCache(true);
+        _cancellationToken = new CancellationTokenSource();
+        _semaphore = new SemaphoreSlim(1, 1);
     }
 
     public string Name => "NextPVR Recordings";
@@ -69,21 +85,26 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
 
     public string GetCacheKey(string userId)
     {
-        var now = DateTime.UtcNow;
+        DateTimeOffset dto = LiveTvService.Instance.RecordingModificationTime;
+        return $"{dto.ToUnixTimeSeconds()}-{_cachekeyBase}";
+    }
 
-        var values = new List<string>();
+    private void CleanCache(bool cleanAll = false)
+    {
+        if (!string.IsNullOrEmpty(_recordingCacheDirectory) && Directory.Exists(_recordingCacheDirectory))
+        {
+            string[] cachedJson = Directory.GetFiles(_recordingCacheDirectory, "*.json");
+            _logger.LogInformation("Cleaning JSON cache {0} {1}", _recordingCacheDirectory, cachedJson.Length);
+            foreach (string fileName in cachedJson)
+            {
+                if (cleanAll == true || _fileSystem.GetLastWriteTimeUtc(fileName).Add(TimeSpan.FromHours(3)) <= DateTimeOffset.UtcNow)
+                {
+                    _fileSystem.DeleteFile(fileName);
+                }
+            }
+        }
 
-        values.Add(now.DayOfYear.ToString(CultureInfo.InvariantCulture));
-        values.Add(now.Hour.ToString(CultureInfo.InvariantCulture));
-
-        double minute = now.Minute;
-        minute /= 5;
-
-        values.Add(Math.Floor(minute).ToString(CultureInfo.InvariantCulture));
-
-        values.Add(GetService().LastRecordingChange.Ticks.ToString(CultureInfo.InvariantCulture));
-
-        return string.Join('-', values.ToArray());
+        return;
     }
 
     public InternalChannelFeatures GetChannelFeatures()
@@ -114,9 +135,24 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
     private LiveTvService GetService()
     {
         LiveTvService service = LiveTvService.Instance;
-        if (service is not null && !service.IsActive)
+        if (service is not null && (!service.IsActive || _cachedRecordingModificationTime != Plugin.Instance.Configuration.RecordingModificationTime || service.FlagRecordingChange))
         {
-            service.EnsureConnectionAsync(new System.Threading.CancellationToken(false)).Wait();
+            try
+            {
+                CancellationToken cancellationToken = CancellationToken.None;
+                service.EnsureConnectionAsync(cancellationToken).Wait();
+                if (service.IsActive)
+                {
+                    _useCachedRecordings = false;
+                    if (_cachedRecordingModificationTime != Plugin.Instance.Configuration.RecordingModificationTime)
+                    {
+                        _cachedRecordingModificationTime = Plugin.Instance.Configuration.RecordingModificationTime;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
         }
 
         return service;
@@ -124,11 +160,21 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
 
     public bool CanDelete(BaseItem item)
     {
+        if (_cachedRecordingModificationTime != Plugin.Instance.Configuration.RecordingModificationTime)
+        {
+            return false;
+        }
+
         return !item.IsFolder;
     }
 
     public Task DeleteItem(string id, CancellationToken cancellationToken)
     {
+        if (_cachedRecordingModificationTime != Plugin.Instance.Configuration.RecordingModificationTime)
+        {
+            return Task.FromException(new InvalidOperationException("Recordings not reloaded"));
+        }
+
         var service = GetService();
         return service is null
             ? Task.CompletedTask
@@ -142,61 +188,54 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
         return result.Items.OrderByDescending(i => i.DateCreated ?? DateTime.MinValue);
     }
 
-    public Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, CancellationToken cancellationToken)
+    public async Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, CancellationToken cancellationToken)
     {
+        await GetRecordingsAsync("GetChannelItems", cancellationToken);
+
         if (string.IsNullOrWhiteSpace(query.FolderId))
         {
-            return GetRecordingGroups(query, cancellationToken);
+            return await GetRecordingGroups(query, cancellationToken);
         }
 
         if (query.FolderId.StartsWith("series_", StringComparison.OrdinalIgnoreCase))
         {
             var hash = query.FolderId.Split('_')[1];
-            return GetChannelItems(query, i => i.IsSeries && string.Equals(i.Name.GetMD5().ToString("N"), hash, StringComparison.Ordinal), cancellationToken);
+            return await GetChannelItems(query, i => i.IsSeries && string.Equals(i.Name.GetMD5().ToString("N"), hash, StringComparison.Ordinal), cancellationToken);
         }
 
         if (string.Equals(query.FolderId, "kids", StringComparison.OrdinalIgnoreCase))
         {
-            return GetChannelItems(query, i => i.IsKids, cancellationToken);
+            return await GetChannelItems(query, i => i.IsKids, cancellationToken);
         }
 
         if (string.Equals(query.FolderId, "movies", StringComparison.OrdinalIgnoreCase))
         {
-            return GetChannelItems(query, i => i.IsMovie, cancellationToken);
+            return await GetChannelItems(query, i => i.IsMovie, cancellationToken);
         }
 
         if (string.Equals(query.FolderId, "news", StringComparison.OrdinalIgnoreCase))
         {
-            return GetChannelItems(query, i => i.IsNews, cancellationToken);
+            return await GetChannelItems(query, i => i.IsNews, cancellationToken);
         }
 
         if (string.Equals(query.FolderId, "sports", StringComparison.OrdinalIgnoreCase))
         {
-            return GetChannelItems(query, i => i.IsSports, cancellationToken);
+            return await GetChannelItems(query, i => i.IsSports, cancellationToken);
         }
 
         if (string.Equals(query.FolderId, "others", StringComparison.OrdinalIgnoreCase))
         {
-            return GetChannelItems(query, i => !i.IsSports && !i.IsNews && !i.IsMovie && !i.IsKids && !i.IsSeries, cancellationToken);
+            return await GetChannelItems(query, i => !i.IsSports && !i.IsNews && !i.IsMovie && !i.IsKids && !i.IsSeries, cancellationToken);
         }
 
         var result = new ChannelItemResult() { Items = new List<ChannelItemInfo>() };
 
-        return Task.FromResult(result);
+        return result;
     }
 
     public async Task<ChannelItemResult> GetChannelItems(InternalChannelItemQuery query, Func<MyRecordingInfo, bool> filter, CancellationToken cancellationToken)
     {
-        var service = GetService();
-        if (_useCachedRecordings == false)
-        {
-            _allRecordings = await service.GetAllRecordingsAsync(cancellationToken).ConfigureAwait(false);
-
-            await service.GetChannelsAsync(cancellationToken).ConfigureAwait(false);
-
-            _useCachedRecordings = true;
-        }
-
+        await GetRecordingsAsync("GetChannelItems", cancellationToken);
         List<ChannelItemInfo> pluginItems = new List<ChannelItemInfo>();
         pluginItems.AddRange(_allRecordings.Where(filter).Select(ConvertToChannelItem));
         var result = new ChannelItemResult() { Items = pluginItems };
@@ -212,9 +251,11 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
         {
             Name = string.IsNullOrEmpty(item.EpisodeTitle) ? item.Name : item.EpisodeTitle,
             SeriesName = !string.IsNullOrEmpty(item.EpisodeTitle) || item.IsSeries ? item.Name : null,
+            StartDate = item.StartDate,
+            EndDate = item.EndDate,
             OfficialRating = item.OfficialRating,
             CommunityRating = item.CommunityRating,
-            ContentType = item.IsMovie ? ChannelMediaContentType.Movie : (item.IsSeries ? ChannelMediaContentType.Episode : ChannelMediaContentType.Clip),
+            ContentType = item.IsMovie ? ChannelMediaContentType.Movie : ChannelMediaContentType.Episode,
             Genres = item.Genres,
             ImageUrl = item.ImageUrl,
             Id = item.Id,
@@ -226,112 +267,164 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
                 new MediaSourceInfo
                 {
                     Path = path,
+                    Container = item.Status == RecordingStatus.InProgress ? "ts" : null,
                     Protocol = path.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? MediaProtocol.Http : MediaProtocol.File,
-                    Id = item.Id,
+                    BufferMs = 1000,
+                    AnalyzeDurationMs = 0,
                     IsInfiniteStream = item.Status == RecordingStatus.InProgress,
-                    RunTimeTicks = (item.EndDate - item.StartDate).Ticks,
+                    TranscodingContainer = "ts",
+                    RunTimeTicks = item.Status == RecordingStatus.InProgress ? null : (item.EndDate - item.StartDate).Ticks,
                 }
             },
             PremiereDate = item.OriginalAirDate,
             ProductionYear = item.ProductionYear,
             Type = ChannelItemType.Media,
-            DateModified = LiveTvService.Instance.DateRecordingModified,
+            DateModified = item.Status == RecordingStatus.InProgress ? DateTime.Now : Plugin.Instance.Configuration.RecordingModificationTime,
             Overview = item.Overview,
-            IsLiveStream = item.Status == RecordingStatus.InProgress,
+            IsLiveStream = item.Status != RecordingStatus.InProgress ? false : Plugin.Instance.Configuration.EnableInProgress,
             Etag = item.Status.ToString()
         };
 
         return channelItem;
     }
 
+    private async Task<bool> GetRecordingsAsync(string name, CancellationToken cancellationToken)
+    {
+        var service = GetService();
+        if (service is null || !service.IsActive)
+        {
+            return false;
+        }
+
+        if (_useCachedRecordings == false || service.FlagRecordingChange)
+        {
+            if (_pollInterval == -1)
+            {
+                var interval = TimeSpan.FromSeconds(Plugin.Instance.Configuration.PollInterval);
+                _updateTimer = new Timer(OnUpdateTimerCallbackAsync, null, TimeSpan.FromMinutes(2), interval);
+                if (_updateTimer != null)
+                {
+                    _pollInterval = Plugin.Instance.Configuration.PollInterval;
+                }
+            }
+
+            if (await _semaphore.WaitAsync(30000, cancellationToken))
+            {
+                try
+                {
+                    _logger.LogDebug("{0} Reload cache", name);
+                    _allRecordings = await service.GetAllRecordingsAsync(cancellationToken).ConfigureAwait(false);
+                    int maxId = _allRecordings.Max(r => int.Parse(r.Id, CultureInfo.InvariantCulture));
+                    int inProcessCount = _allRecordings.Where(r => r.Status == RecordingStatus.InProgress).Count();
+                    string keyBase = $"{maxId}-{inProcessCount}-{_allRecordings.Count()}";
+                    if (keyBase != _cachekeyBase && !service.FlagRecordingChange)
+                    {
+                        _logger.LogDebug("External recording list change {0}", keyBase);
+                        CleanCache(true);
+                    }
+
+                    _cachekeyBase = keyBase;
+                    _lastUpdate = DateTimeOffset.UtcNow;
+                    service.FlagRecordingChange = false;
+                    _useCachedRecordings = true;
+                }
+                catch (Exception)
+                {
+                }
+
+                _semaphore.Release();
+            }
+        }
+
+        return _useCachedRecordings;
+    }
+
     private async Task<ChannelItemResult> GetRecordingGroups(InternalChannelItemQuery query, CancellationToken cancellationToken)
     {
         List<ChannelItemInfo> pluginItems = new List<ChannelItemInfo>();
-        var service = GetService();
-        if (_useCachedRecordings == false)
-        {
-            _allRecordings = await service.GetAllRecordingsAsync(cancellationToken).ConfigureAwait(false);
-            await service.GetChannelsAsync(cancellationToken).ConfigureAwait(false);
-            _useCachedRecordings = true;
-        }
 
-        var series = _allRecordings
-            .Where(i => i.IsSeries)
-            .ToLookup(i => i.Name, StringComparer.OrdinalIgnoreCase);
-
-        pluginItems.AddRange(series.OrderBy(i => i.Key).Select(i => new ChannelItemInfo
+        if (await GetRecordingsAsync("GetRecordingGroups", cancellationToken))
         {
-            Name = i.Key,
-            FolderType = ChannelFolderType.Container,
-            Id = "series_" + i.Key.GetMD5().ToString("N"),
-            Type = ChannelItemType.Folder,
-            DateCreated = i.Last().StartDate,
-            ImageUrl = i.Last().ImageUrl.Replace("=poster", "=landscape", StringComparison.OrdinalIgnoreCase)
-        }));
-        var kids = _allRecordings.FirstOrDefault(i => i.IsKids);
+            var series = _allRecordings
+                .Where(i => i.IsSeries)
+                .ToLookup(i => i.Name, StringComparer.OrdinalIgnoreCase);
 
-        if (kids != null)
-        {
-            pluginItems.Add(new ChannelItemInfo
+            pluginItems.AddRange(series.OrderBy(i => i.Key).Select(i => new ChannelItemInfo
             {
-                Name = "Kids",
+                Name = i.Key,
                 FolderType = ChannelFolderType.Container,
-                Id = "kids",
+                Id = "series_" + i.Key.GetMD5().ToString("N"),
                 Type = ChannelItemType.Folder,
-                ImageUrl = kids.ImageUrl
-            });
-        }
+                DateCreated = i.Last().StartDate,
+                ImageUrl = i.Last().ImageUrl.Replace("=poster", "=landscape", StringComparison.OrdinalIgnoreCase)
+            }));
 
-        var movies = _allRecordings.FirstOrDefault(i => i.IsMovie);
-        if (movies != null)
-        {
-            pluginItems.Add(new ChannelItemInfo
-            {
-                Name = "Movies",
-                FolderType = ChannelFolderType.Container,
-                Id = "movies",
-                Type = ChannelItemType.Folder,
-                ImageUrl = movies.ImageUrl
-            });
-        }
+            var kids = _allRecordings.FirstOrDefault(i => i.IsKids);
 
-        var news = _allRecordings.FirstOrDefault(i => i.IsNews);
-        if (news != null)
-        {
-            pluginItems.Add(new ChannelItemInfo
+            if (kids != null)
             {
-                Name = "News",
-                FolderType = ChannelFolderType.Container,
-                Id = "news",
-                Type = ChannelItemType.Folder,
-                ImageUrl = news.ImageUrl
-            });
-        }
+                pluginItems.Add(new ChannelItemInfo
+                {
+                    Name = "Kids",
+                    FolderType = ChannelFolderType.Container,
+                    Id = "kids",
+                    Type = ChannelItemType.Folder,
+                    ImageUrl = kids.ImageUrl
+                });
+            }
 
-        var sports = _allRecordings.FirstOrDefault(i => i.IsSports);
-        if (sports != null)
-        {
-            pluginItems.Add(new ChannelItemInfo
+            var movies = _allRecordings.FirstOrDefault(i => i.IsMovie);
+            if (movies != null)
             {
-                Name = "Sports",
-                FolderType = ChannelFolderType.Container,
-                Id = "sports",
-                Type = ChannelItemType.Folder,
-                ImageUrl = sports.ImageUrl
-            });
-        }
+                pluginItems.Add(new ChannelItemInfo
+                {
+                    Name = "Movies",
+                    FolderType = ChannelFolderType.Container,
+                    Id = "movies",
+                    Type = ChannelItemType.Folder,
+                    ImageUrl = movies.ImageUrl
+                });
+            }
 
-        var other = _allRecordings.FirstOrDefault(i => !i.IsSports && !i.IsNews && !i.IsMovie && !i.IsKids && !i.IsSeries);
-        if (other != null)
-        {
-            pluginItems.Add(new ChannelItemInfo
+            var news = _allRecordings.FirstOrDefault(i => i.IsNews);
+            if (news != null)
             {
-                Name = "Others",
-                FolderType = ChannelFolderType.Container,
-                Id = "others",
-                Type = ChannelItemType.Folder,
-                ImageUrl = other.ImageUrl
-            });
+                pluginItems.Add(new ChannelItemInfo
+                {
+                    Name = "News",
+                    FolderType = ChannelFolderType.Container,
+                    Id = "news",
+                    Type = ChannelItemType.Folder,
+                    ImageUrl = news.ImageUrl
+                });
+            }
+
+            var sports = _allRecordings.FirstOrDefault(i => i.IsSports);
+            if (sports != null)
+            {
+                pluginItems.Add(new ChannelItemInfo
+                {
+                    Name = "Sports",
+                    FolderType = ChannelFolderType.Container,
+                    Id = "sports",
+                    Type = ChannelItemType.Folder,
+                    ImageUrl = sports.ImageUrl
+                });
+            }
+
+            var other = _allRecordings.OrderByDescending(j => j.StartDate).FirstOrDefault(i => !i.IsSports && !i.IsNews && !i.IsMovie && !i.IsKids && !i.IsSeries);
+            if (other != null)
+            {
+                pluginItems.Add(new ChannelItemInfo
+                {
+                    Name = "Others",
+                    FolderType = ChannelFolderType.Container,
+                    Id = "others",
+                    Type = ChannelItemType.Folder,
+                    DateModified = other.StartDate,
+                    ImageUrl = other.ImageUrl
+                });
+            }
         }
 
         var result = new ChannelItemResult() { Items = pluginItems };
@@ -340,15 +433,21 @@ public class RecordingsChannel : IChannel, IHasCacheKey, ISupportsDelete, ISuppo
 
     private async void OnUpdateTimerCallbackAsync(object state)
     {
-        var service = GetService();
+        LiveTvService service = LiveTvService.Instance;
         if (service is not null && service.IsActive)
         {
             var backendUpdate = await service.GetLastUpdate(_cancellationToken.Token).ConfigureAwait(false);
             if (backendUpdate > _lastUpdate)
             {
+                _logger.LogDebug("Recordings reset {0}", backendUpdate);
                 _useCachedRecordings = false;
-                _lastUpdate = backendUpdate;
+                await GetRecordingsAsync("OnUpdateTimerCallbackAsync", _cancellationToken.Token);
             }
         }
+    }
+
+    public bool HasChanged(BaseItem item, IDirectoryService directoryService)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Jellyfin.Plugin.NextPVR/Responses/SettingResponse.cs
+++ b/Jellyfin.Plugin.NextPVR/Responses/SettingResponse.cs
@@ -1,6 +1,6 @@
-using System.Globalization;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Jellyfin.Extensions.Json;
 using Jellyfin.Plugin.NextPVR.Helpers;
@@ -16,9 +16,10 @@ public class SettingResponse
     {
         var root = await JsonSerializer.DeserializeAsync<ScheduleSettings>(stream, _jsonOptions).ConfigureAwait(false);
         UtilsHelper.DebugInformation(logger, $"[NextPVR] GetDefaultTimerInfo Response: {JsonSerializer.Serialize(root, _jsonOptions)}");
-        Plugin.Instance.Configuration.PostPaddingSeconds = int.Parse(root.PostPadding, CultureInfo.InvariantCulture) * 60;
-        Plugin.Instance.Configuration.PrePaddingSeconds = int.Parse(root.PrePadding, CultureInfo.InvariantCulture) * 60;
+        Plugin.Instance.Configuration.PostPaddingSeconds = root.PostPadding;
+        Plugin.Instance.Configuration.PrePaddingSeconds = root.PrePadding;
         Plugin.Instance.Configuration.ShowRepeat = root.ShowNewInGuide;
+        Plugin.Instance.Configuration.BackendVersion = root.NextPvrVersion;
         return true;
     }
 
@@ -35,7 +36,8 @@ public class SettingResponse
     {
         public string Version { get; set; }
 
-        public string NextPvrVersion { get; set; }
+        [JsonPropertyName("nextPVRVersion")]
+        public int NextPvrVersion { get; set; }
 
         public string ReadableVersion { get; set; }
 
@@ -59,9 +61,9 @@ public class SettingResponse
 
         public string RecordingView { get; set; }
 
-        public string PrePadding { get; set; }
+        public int PrePadding { get; set; }
 
-        public string PostPadding { get; set; }
+        public int PostPadding { get; set; }
 
         public bool ConfirmOnDelete { get; set; }
 

--- a/Jellyfin.Plugin.NextPVR/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.NextPVR/ServiceRegistrator.cs
@@ -1,6 +1,4 @@
-using Jellyfin.Plugin.NextPVR;
 using MediaBrowser.Controller;
-using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Plugins;

--- a/Jellyfin.Plugin.NextPVR/Web/nextpvr.html
+++ b/Jellyfin.Plugin.NextPVR/Web/nextpvr.html
@@ -22,6 +22,20 @@
                     </label>
                 </div>
 
+                <div class="checkboxContainer">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="chkInProgress" />
+                        <span>Force in-progress recordings</span>
+                    </label>
+                </div>
+
+                <div class="inputContainer">
+                    <input is="emby-input" type="number" id="numPoll" required pattern="[0-9]*" min="0" max="600" step="10" label="Poll NextPVR Server"/>
+                    <div class="fieldDescription">
+                        Check to reload recording changes from the server in (seconds). Use 0 to disable polling.
+                    </div>
+                </div>
+
                 <div class="selectContainer">
                     <select is="emby-select" id="selRecDefault" label="Series Recording Default">
                         <option value="1">New episodes on this channel</option>
@@ -34,8 +48,9 @@
 
                 <div class="selectContainer">
                     <select is="emby-select" id="selRecTransport" label="Recording Protocol">
-                        <option value="1">Streaming</option>
                         <option value="2">Filename</option>
+                        <option value="1">Streaming</option>
+                        <option value="3">Unauthenticated streaming</option>
                     </select>
                 </div>
 


### PR DESCRIPTION
Recording changes

I. General

- reload recordings and reset modification time when a settings change impacts recordings
- delete recording channel json cache to allow for changes outside of Jellyfin.  JF only calls for new recordings when the database entries are not cached
- use episode mode without S/E for all non movie recordings, Jellyfin was using the subtitle as title and not displaying the title on clips.
- parse duplicated S/E information from the sub-title passed in the API.
- change cache key, add-on was using a key that changed often, leaving orphan JSON in the cache for every recording

II. Recording polling

In 10.9 Jellyfin was re-enabling disabled plugin causing user performance issues (not sure why though)

- don't poll for recording until connected
- reduce initial connection time to 5 seconds to avoid overlapping connection attempts
- allow configuration of polling interval, the more frequent the more responsive the addon is to changes outside Jellyfin
- catch connection errors in the plugin, don't throw errors to core.

III. In-progress recordings problems

a) In-progress recordings do not play when recordings are flagged as in-progress

- default in-progress to direct play.
- append growing flag to recordings to not send content-length.

b) No resume while in-progress

- don't know what to do to make this work.

c) Slow playback on initial in-progress recordings

- cannot change the analyzeduration so FFprobe waits for 200MB before playback
- if users give up, orphan FFmpeg tasks could be left running.
- don't know what to do to make this work.

IV. Security changes

- configure IPv4 so FFmpeg doesn't use IPv6 when a hostname is specified
- adapt to NextPVR unauthenticated access fix starting in 6.1.6
- allow unauthenticated recording streaming so clients can direct play.  Jellyfin does not proxy client so security was failing and only transcoded play was available.

