### PR TITLE
Fix unhandled TaskCancelledException for HTTPClient

### DIFF
--- a/Jellyfin.Plugin.NextPVR/LiveTvService.cs
+++ b/Jellyfin.Plugin.NextPVR/LiveTvService.cs
@@ -621,10 +621,10 @@ public class LiveTvService : ILiveTvService
 
             UtilsHelper.DebugInformation(_logger, $"GetLastUpdateTime {retTime.ToUnixTimeSeconds()}");
         }
-        catch (HttpRequestException)
+        catch (Exception ex)
         {
             LastUpdatedSidDateTime = DateTimeOffset.MinValue;
-            _logger.LogWarning("Could not connect to servier");
+            _logger.LogWarning(ex, "Could not connect to server");
             Sid = null;
         }
 


### PR DESCRIPTION
Fixes jellyfin crashes when the connection to the NextPVR server timeout (timeout is set to 5 seconds in LiveTvService).

Closes #59